### PR TITLE
Add SP111 board with HLW8012 support and calibration settings

### DIFF
--- a/src/include/board/sp111.c
+++ b/src/include/board/sp111.c
@@ -1,0 +1,219 @@
+/*
+ Copyright (C) AC SOFTWARE SP. Z O.O.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+ */
+
+#include <gpio.h>
+
+#include "supla_esp.h"
+#include "supla_hlw8012.h"
+
+static supla_hlw8012_t hlw;
+static ETSTimer hlw_mode_timer;
+
+#define SP111_HLW_CURRENT_MULTIPLIER 0.0025f
+#define SP111_HLW_VOLTAGE_MULTIPLIER 0.50f
+#define SP111_HLW_POWER_MULTIPLIER 1.0f
+
+static void ICACHE_FLASH_ATTR supla_esp_board_hlw_apply_sel(void) {
+  if (hlw.cf1_mode == SUPLA_HLW8012_CF1_MODE_CURRENT) {
+    supla_esp_gpio_set_hi(B_HLW_SEL_PORT, 1);
+  } else {
+    supla_esp_gpio_set_hi(B_HLW_SEL_PORT, 0);
+  }
+}
+
+static void ICACHE_FLASH_ATTR supla_esp_board_hlw_mode_timer_cb(void *arg) {
+  (void)arg;
+  if (hlw.cf1_mode == SUPLA_HLW8012_CF1_MODE_CURRENT) {
+    supla_hlw8012_set_cf1_mode(&hlw, SUPLA_HLW8012_CF1_MODE_VOLTAGE);
+  } else {
+    supla_hlw8012_set_cf1_mode(&hlw, SUPLA_HLW8012_CF1_MODE_CURRENT);
+  }
+
+  supla_esp_board_hlw_apply_sel();
+}
+
+void ICACHE_FLASH_ATTR supla_esp_board_starting(void) {
+  supla_hlw8012_config_t cfg;
+  memset(&cfg, 0, sizeof(cfg));
+
+  float voltage_cal = supla_esp_cfg.HlwVoltageCalibration == 0
+                          ? 1.0f
+                          : supla_esp_cfg.HlwVoltageCalibration / 1000.0f;
+  float energy_cal = supla_esp_cfg.HlwEnergyCalibration == 0
+                         ? 1.0f
+                         : supla_esp_cfg.HlwEnergyCalibration / 1000.0f;
+
+  cfg.current_multiplier = SP111_HLW_CURRENT_MULTIPLIER;
+  cfg.voltage_multiplier = SP111_HLW_VOLTAGE_MULTIPLIER * voltage_cal;
+  cfg.power_multiplier = SP111_HLW_POWER_MULTIPLIER * energy_cal;
+  cfg.stale_time_us = 3000000;
+
+  supla_hlw8012_init(&hlw, &cfg);
+  supla_hlw8012_set_cf1_mode(&hlw, SUPLA_HLW8012_CF1_MODE_VOLTAGE);
+  supla_esp_board_hlw_apply_sel();
+
+  GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, BIT(B_HLW_CF_PORT));
+  GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, BIT(B_HLW_CF1_PORT));
+  gpio_pin_intr_state_set(GPIO_ID_PIN(B_HLW_CF_PORT), GPIO_PIN_INTR_ANYEDGE);
+  gpio_pin_intr_state_set(GPIO_ID_PIN(B_HLW_CF1_PORT), GPIO_PIN_INTR_ANYEDGE);
+
+  os_timer_disarm(&hlw_mode_timer);
+  os_timer_setfn(&hlw_mode_timer,
+                 (os_timer_func_t *)supla_esp_board_hlw_mode_timer_cb, NULL);
+  os_timer_arm(&hlw_mode_timer, 2000, 1);
+}
+
+void supla_esp_board_set_device_name(char *buffer, uint8 buffer_size) {
+  ets_snprintf(buffer, buffer_size, "SP111");
+}
+
+void supla_esp_board_gpio_init(void) {
+  supla_input_cfg[0].type = INPUT_TYPE_BTN_MONOSTABLE;
+  supla_input_cfg[0].gpio_id = B_CFG_PORT;
+  supla_input_cfg[0].flags = INPUT_FLAG_PULLUP | INPUT_FLAG_CFG_BTN;
+  supla_input_cfg[0].relay_gpio_id = B_RELAY1_PORT;
+  supla_input_cfg[0].channel = 0;
+
+  supla_relay_cfg[0].gpio_id = B_RELAY1_PORT;
+  supla_relay_cfg[0].flags = RELAY_FLAG_RESTORE_FORCE;
+  supla_relay_cfg[0].channel = 0;
+
+  supla_input_cfg[1].type = INPUT_TYPE_CUSTOM;
+  supla_input_cfg[1].gpio_id = B_HLW_CF_PORT;
+  supla_input_cfg[1].flags = INPUT_FLAG_DISABLE_INTR;
+
+  supla_input_cfg[2].type = INPUT_TYPE_CUSTOM;
+  supla_input_cfg[2].gpio_id = B_HLW_CF1_PORT;
+  supla_input_cfg[2].flags = INPUT_FLAG_DISABLE_INTR;
+
+  PIN_PULLUP_EN(PERIPHS_IO_MUX_GPIO0_U);
+}
+
+uint8 supla_esp_board_intr_handler(uint32 gpio_status) {
+  uint8 result = 0;
+
+  if (gpio_status & BIT(B_HLW_CF_PORT)) {
+    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & BIT(B_HLW_CF_PORT));
+    if (gpio__input_get(B_HLW_CF_PORT)) {
+      supla_hlw8012_on_cf_pulse(&hlw, system_get_time());
+    }
+    gpio_pin_intr_state_set(GPIO_ID_PIN(B_HLW_CF_PORT), GPIO_PIN_INTR_ANYEDGE);
+    result = 1;
+  }
+
+  if (gpio_status & BIT(B_HLW_CF1_PORT)) {
+    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS,
+                   gpio_status & BIT(B_HLW_CF1_PORT));
+    if (gpio__input_get(B_HLW_CF1_PORT)) {
+      supla_hlw8012_on_cf1_pulse(&hlw, system_get_time());
+    }
+    gpio_pin_intr_state_set(GPIO_ID_PIN(B_HLW_CF1_PORT),
+                            GPIO_PIN_INTR_ANYEDGE);
+    result = 1;
+  }
+
+  return result;
+}
+
+uint8 ICACHE_FLASH_ATTR supla_esp_board_get_measurements(
+    unsigned char channel_number, TElectricityMeter_ExtendedValue_V2 *ev) {
+  supla_hlw8012_values_t values;
+
+  if (channel_number != ELECTRICITY_METER_CHANNEL_OFFSET || ev == NULL) {
+    return 0;
+  }
+
+  memset(ev, 0, sizeof(TElectricityMeter_ExtendedValue_V2));
+  supla_hlw8012_get_values(&hlw, system_get_time(), &values);
+
+  ev->measured_values = EM_VAR_FORWARD_ACTIVE_ENERGY;
+  ev->total_forward_active_energy[0] = (_supla_int64_t)(values.energy_wh * 100);
+
+  if (values.power_w > 0.01f) {
+    ev->measured_values |= EM_VAR_POWER_ACTIVE;
+    ev->m[0].power_active[0] = (_supla_int_t)(values.power_w * 100000);
+  }
+
+  if (values.voltage_v > 0.01f) {
+    ev->measured_values |= EM_VAR_VOLTAGE;
+    ev->m[0].voltage[0] = (_supla_int16_t)(values.voltage_v * 100);
+  }
+
+  if (values.current_a > 0.001f) {
+    ev->measured_values |= EM_VAR_CURRENT;
+    ev->m[0].current[0] = (_supla_int16_t)(values.current_a * 1000);
+  }
+
+  if (values.power_factor > 0.001f) {
+    ev->measured_values |= EM_VAR_POWER_FACTOR;
+    ev->m[0].power_factor[0] = (_supla_int16_t)(values.power_factor * 1000);
+  }
+
+  if (values.voltage_v > 0.01f && values.current_a > 0.001f) {
+    ev->measured_values |= EM_VAR_POWER_APPARENT;
+    ev->m[0].power_apparent[0] =
+        (_supla_int_t)(values.voltage_v * values.current_a * 100000);
+  }
+
+  ev->m_count = 1;
+  return 1;
+}
+
+void supla_esp_board_set_channels(TDS_SuplaDeviceChannel_C *channels,
+                                  unsigned char *channel_count) {
+  *channel_count = 2;
+
+  channels[0].Number = 0;
+  channels[0].Type = SUPLA_CHANNELTYPE_RELAY;
+  channels[0].FuncList = SUPLA_BIT_FUNC_POWERSWITCH | SUPLA_BIT_FUNC_LIGHTSWITCH;
+  channels[0].Default = SUPLA_CHANNELFNC_POWERSWITCH;
+  channels[0].value[0] = supla_esp_gpio_relay_on(B_RELAY1_PORT);
+
+  channels[1].Number = ELECTRICITY_METER_CHANNEL_OFFSET;
+  channels[1].Type = SUPLA_CHANNELTYPE_IMPULSE_COUNTER;
+  channels[1].Default = SUPLA_CHANNELFNC_ELECTRICITY_METER;
+}
+
+void supla_esp_board_send_channel_values_with_delay(void *srpc) {
+  (void)srpc;
+  supla_esp_channel_value_changed(0, supla_esp_gpio_relay_on(B_RELAY1_PORT));
+}
+
+char *ICACHE_FLASH_ATTR supla_esp_board_cfg_html_template(
+    char dev_name[25], const char mac[6], const char data_saved) {
+  (void)mac;
+  static char html[] =
+      "<!DOCTYPE html><meta charset=\"UTF-8\"><html><body>"
+      "<h2>%s</h2>%s"
+      "<form method=\"post\">"
+      "SSID:<input name=\"sid\" value=\"%s\"><br>"
+      "Haslo WiFi:<input name=\"wpw\"><br>"
+      "Serwer:<input name=\"svr\" value=\"%s\"><br>"
+      "Email:<input name=\"eml\" value=\"%s\"><br>"
+      "Kalibracja napiecia (promile):<input name=\"hvc\" value=\"%u\"><br>"
+      "Kalibracja energii (promile):<input name=\"hec\" value=\"%u\"><br>"
+      "<button type=\"submit\">SAVE</button>"
+      "</form></body></html>";
+
+  int bufflen = strlen(html) + strlen(dev_name) + strlen(supla_esp_cfg.WIFI_SSID) +
+                strlen(supla_esp_cfg.Server) + strlen(supla_esp_cfg.Email) + 80;
+  char *buffer = (char *)malloc(bufflen);
+
+  ets_snprintf(buffer, bufflen, html, dev_name,
+               data_saved == 1 ? "<p>Data saved</p>" : "", supla_esp_cfg.WIFI_SSID,
+               supla_esp_cfg.Server, supla_esp_cfg.Email,
+               supla_esp_cfg.HlwVoltageCalibration == 0
+                   ? 1000
+                   : supla_esp_cfg.HlwVoltageCalibration,
+               supla_esp_cfg.HlwEnergyCalibration == 0
+                   ? 1000
+                   : supla_esp_cfg.HlwEnergyCalibration);
+
+  return buffer;
+}

--- a/src/include/board/sp111.h
+++ b/src/include/board/sp111.h
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) AC SOFTWARE SP. Z O.O.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+ */
+
+#ifndef SP111_H_
+#define SP111_H_
+
+#define ESP8266_SUPLA_PROTO_VERSION 16
+
+#define AP_SSID "SP111"
+
+#define B_RELAY1_PORT 12
+#define B_CFG_PORT 0
+#define B_HLW_CF_PORT 5
+#define B_HLW_CF1_PORT 14
+#define B_HLW_SEL_PORT 13
+#define LED_RED_PORT 2
+
+#define ELECTRICITY_METER_COUNT 1
+#define ELECTRICITY_METER_CHANNEL_OFFSET 1
+
+#define BOARD_CFG_HTML_TEMPLATE
+#define BOARD_INTR_HANDLER \
+  if (supla_esp_board_intr_handler(gpio_status)) return
+#define BOARD_ESP_STARTING supla_esp_board_starting();
+
+char *ICACHE_FLASH_ATTR supla_esp_board_cfg_html_template(
+    char dev_name[25], const char mac[6], const char data_saved);
+
+void ICACHE_FLASH_ATTR supla_esp_board_starting(void);
+uint8 ICACHE_FLASH_ATTR supla_esp_board_get_measurements(
+    unsigned char channel_number, TElectricityMeter_ExtendedValue_V2 *ev);
+uint8 supla_esp_board_intr_handler(uint32 gpio_status);
+
+void supla_esp_board_send_channel_values_with_delay(void *srpc);
+
+#endif

--- a/src/include/board/supla_esp_board.c
+++ b/src/include/board/supla_esp_board.c
@@ -189,6 +189,10 @@
 
 #include "board/k_vindriktning.c"
 
+#elif defined(__BOARD_sp111)
+
+#include "board/sp111.c"
+
 #elif defined(__BOARD_k_versa_module)
 
 #include "board/k_versa_module.c"

--- a/src/include/board/supla_esp_board.h
+++ b/src/include/board/supla_esp_board.h
@@ -198,6 +198,10 @@
 
 #include "board/k_vindriktning.h"
 
+#elif defined(__BOARD_sp111)
+
+#include "board/sp111.h"
+
 #elif defined(__BOARD_k_versa_module)
 
 #include "board/k_versa_module.h"

--- a/src/user/supla_esp_cfg.h
+++ b/src/user/supla_esp_cfg.h
@@ -131,13 +131,17 @@ typedef struct {
   unsigned char Tilt100Angle[RS_MAX_COUNT];  // not used in device
   unsigned char TiltControlType[RS_MAX_COUNT];
   signed char AdditionalTimeMargin[RS_MAX_COUNT];
+  uint32_t HlwVoltageCalibration;
+  uint32_t HlwEnergyCalibration;
   char zero[200
             - CFG_TIME3_COUNT * sizeof(unsigned int)  // Time3
             - sizeof(char)  // ButtonsUpsideDown
             - RS_MAX_COUNT * sizeof(unsigned char)  // Tilt0Angle
             - RS_MAX_COUNT * sizeof(unsigned char)  // Tilt100Angle
             - RS_MAX_COUNT * sizeof(unsigned char)  // TiltControlType
-            - RS_MAX_COUNT * sizeof(signed char)];  // AdditionalTimeMargin
+            - RS_MAX_COUNT * sizeof(signed char)  // AdditionalTimeMargin
+            - sizeof(uint32_t)  // HlwVoltageCalibration
+            - sizeof(uint32_t)];  // HlwEnergyCalibration
 } SuplaEspCfg;
 
 typedef struct {

--- a/src/user/supla_esp_cfgmode.c
+++ b/src/user/supla_esp_cfgmode.c
@@ -130,6 +130,9 @@
 #define VAR_T33 75
 #endif /*CFG_TIME_VARIABLES*/
 
+#define VAR_HVC 76  // HLW voltage calibration
+#define VAR_HEC 77  // HLW energy calibration
+
 typedef struct {
   char step;
   char type;
@@ -438,6 +441,8 @@ void ICACHE_FLASH_ATTR supla_esp_parse_vars(TrivialHttpParserVars *pVars,
       char tc1[3] = {'t', 'c', '1'};  // Tilt control type idx 1
       char tc2[3] = {'t', 'c', '2'};  // Tilt control type idx 2
       char tc3[3] = {'t', 'c', '3'};  // Tilt control type idx 3
+      char hvc[3] = {'h', 'v', 'c'};
+      char hec[3] = {'h', 'e', 'c'};
 
       if (len - a >= 4 && pdata[a + 3] == '=') {
         if (memcmp(sid, &pdata[a], 3) == 0) {
@@ -494,6 +499,16 @@ void ICACHE_FLASH_ATTR supla_esp_parse_vars(TrivialHttpParserVars *pVars,
 
         } else if (memcmp(led, &pdata[a], 3) == 0) {
           pVars->current_var = VAR_LED;
+          pVars->buff_size = 12;
+          pVars->pbuff = pVars->intval;
+
+        } else if (memcmp(hvc, &pdata[a], 3) == 0) {
+          pVars->current_var = VAR_HVC;
+          pVars->buff_size = 12;
+          pVars->pbuff = pVars->intval;
+
+        } else if (memcmp(hec, &pdata[a], 3) == 0) {
+          pVars->current_var = VAR_HEC;
           pVars->buff_size = 12;
           pVars->pbuff = pVars->intval;
 					
@@ -846,7 +861,25 @@ void ICACHE_FLASH_ATTR supla_esp_parse_vars(TrivialHttpParserVars *pVars,
 
         } else if (pVars->current_var == VAR_LED) {
           cfg->StatusLedOff = (pVars->intval[0] - '0');
-						
+
+        } else if (pVars->current_var == VAR_HVC) {
+          int val = cfg_str2int(pVars->intval);
+          if (val < 500) {
+            val = 500;
+          } else if (val > 2000) {
+            val = 2000;
+          }
+          cfg->HlwVoltageCalibration = val;
+
+        } else if (pVars->current_var == VAR_HEC) {
+          int val = cfg_str2int(pVars->intval);
+          if (val < 500) {
+            val = 500;
+          } else if (val > 2000) {
+            val = 2000;
+          }
+          cfg->HlwEnergyCalibration = val;
+
 #ifdef TEMP_SELECT										// wybor czujnika temperatury
 		} else if ( pVars->current_var == VAR_TRM ) {
 		cfg->ThermometerType = pVars->intval[0] - '0';

--- a/src/user/supla_hlw8012.c
+++ b/src/user/supla_hlw8012.c
@@ -1,0 +1,153 @@
+/*
+ Copyright (C) AC SOFTWARE SP. Z O.O.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+ */
+
+#include "supla_hlw8012.h"
+
+#include <osapi.h>
+
+#define HLW8012_DEFAULT_STALE_TIME_US 2000000
+
+static void ICACHE_FLASH_ATTR supla_hlw8012_clear_measurements(
+    supla_hlw8012_t *hlw) {
+  hlw->last_cf_ts = 0;
+  hlw->last_cf1_ts = 0;
+  hlw->cf_period_us = 0;
+  hlw->cf1_period_us = 0;
+  hlw->cached_voltage_v = 0;
+  hlw->cached_current_a = 0;
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_init(supla_hlw8012_t *hlw,
+                                          const supla_hlw8012_config_t *cfg) {
+  if (hlw == NULL || cfg == NULL) {
+    return;
+  }
+
+  memset(hlw, 0, sizeof(supla_hlw8012_t));
+  memcpy(&hlw->cfg, cfg, sizeof(supla_hlw8012_config_t));
+
+  if (hlw->cfg.stale_time_us == 0) {
+    hlw->cfg.stale_time_us = HLW8012_DEFAULT_STALE_TIME_US;
+  }
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_set_cf1_mode(supla_hlw8012_t *hlw,
+                                                  uint8 cf1_mode) {
+  if (hlw == NULL) {
+    return;
+  }
+
+  if (cf1_mode != SUPLA_HLW8012_CF1_MODE_VOLTAGE &&
+      cf1_mode != SUPLA_HLW8012_CF1_MODE_CURRENT) {
+    return;
+  }
+
+  hlw->cf1_mode = cf1_mode;
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_on_cf_pulse(supla_hlw8012_t *hlw,
+                                                 uint32 timestamp_us) {
+  uint32 period_us = 0;
+
+  if (hlw == NULL) {
+    return;
+  }
+
+  if (hlw->last_cf_ts != 0) {
+    period_us = timestamp_us - hlw->last_cf_ts;
+    if (period_us != 0) {
+      hlw->cf_period_us = period_us;
+      hlw->energy_wh += hlw->cfg.power_multiplier / 3600.0f;
+    }
+  }
+
+  hlw->last_cf_ts = timestamp_us;
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_on_cf1_pulse(supla_hlw8012_t *hlw,
+                                                  uint32 timestamp_us) {
+  uint32 period_us = 0;
+  float freq_hz = 0;
+
+  if (hlw == NULL) {
+    return;
+  }
+
+  if (hlw->last_cf1_ts != 0) {
+    period_us = timestamp_us - hlw->last_cf1_ts;
+    if (period_us != 0) {
+      hlw->cf1_period_us = period_us;
+      freq_hz = 1000000.0f / period_us;
+
+      if (hlw->cf1_mode == SUPLA_HLW8012_CF1_MODE_VOLTAGE) {
+        hlw->cached_voltage_v = freq_hz * hlw->cfg.voltage_multiplier;
+      } else {
+        hlw->cached_current_a = freq_hz * hlw->cfg.current_multiplier;
+      }
+    }
+  }
+
+  hlw->last_cf1_ts = timestamp_us;
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_reset_energy(supla_hlw8012_t *hlw) {
+  if (hlw == NULL) {
+    return;
+  }
+
+  hlw->energy_wh = 0;
+}
+
+void ICACHE_FLASH_ATTR supla_hlw8012_get_values(supla_hlw8012_t *hlw,
+                                                uint32 timestamp_us,
+                                                supla_hlw8012_values_t *values) {
+  uint32 age_cf = 0;
+  uint32 age_cf1 = 0;
+
+  if (hlw == NULL || values == NULL) {
+    return;
+  }
+
+  memset(values, 0, sizeof(supla_hlw8012_values_t));
+
+  if (hlw->last_cf_ts != 0) {
+    age_cf = timestamp_us - hlw->last_cf_ts;
+  }
+
+  if (hlw->last_cf1_ts != 0) {
+    age_cf1 = timestamp_us - hlw->last_cf1_ts;
+  }
+
+  if (hlw->last_cf_ts == 0 || age_cf > hlw->cfg.stale_time_us) {
+    supla_hlw8012_clear_measurements(hlw);
+    values->energy_wh = hlw->energy_wh;
+    return;
+  }
+
+  if (hlw->cf_period_us != 0) {
+    values->power_w = 1000000.0f / hlw->cf_period_us * hlw->cfg.power_multiplier;
+  }
+
+  if (hlw->last_cf1_ts != 0 && age_cf1 <= hlw->cfg.stale_time_us) {
+    values->voltage_v = hlw->cached_voltage_v;
+    values->current_a = hlw->cached_current_a;
+  }
+
+  values->energy_wh = hlw->energy_wh;
+
+  if (values->voltage_v > 0.01f && values->current_a > 0.0001f) {
+    values->power_factor =
+        values->power_w / (values->voltage_v * values->current_a);
+    if (values->power_factor < 0) {
+      values->power_factor = 0;
+    } else if (values->power_factor > 1) {
+      values->power_factor = 1;
+    }
+  }
+}

--- a/src/user/supla_hlw8012.h
+++ b/src/user/supla_hlw8012.h
@@ -1,0 +1,68 @@
+/*
+ Copyright (C) AC SOFTWARE SP. Z O.O.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+ */
+
+#ifndef SUPLA_HLW8012_H_
+#define SUPLA_HLW8012_H_
+
+#include "supla_esp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  SUPLA_HLW8012_CF1_MODE_VOLTAGE = 0,
+  SUPLA_HLW8012_CF1_MODE_CURRENT = 1
+} supla_hlw8012_cf1_mode_t;
+
+typedef struct {
+  float power_multiplier;
+  float voltage_multiplier;
+  float current_multiplier;
+  uint32 stale_time_us;
+} supla_hlw8012_config_t;
+
+typedef struct {
+  float power_w;
+  float voltage_v;
+  float current_a;
+  float energy_wh;
+  float power_factor;
+} supla_hlw8012_values_t;
+
+typedef struct {
+  supla_hlw8012_config_t cfg;
+  uint8 cf1_mode;
+  uint32 last_cf_ts;
+  uint32 last_cf1_ts;
+  uint32 cf_period_us;
+  uint32 cf1_period_us;
+  float cached_voltage_v;
+  float cached_current_a;
+  float energy_wh;
+} supla_hlw8012_t;
+
+void ICACHE_FLASH_ATTR supla_hlw8012_init(supla_hlw8012_t *hlw,
+                                          const supla_hlw8012_config_t *cfg);
+void ICACHE_FLASH_ATTR supla_hlw8012_set_cf1_mode(supla_hlw8012_t *hlw,
+                                                  uint8 cf1_mode);
+void ICACHE_FLASH_ATTR supla_hlw8012_on_cf_pulse(supla_hlw8012_t *hlw,
+                                                 uint32 timestamp_us);
+void ICACHE_FLASH_ATTR supla_hlw8012_on_cf1_pulse(supla_hlw8012_t *hlw,
+                                                  uint32 timestamp_us);
+void ICACHE_FLASH_ATTR supla_hlw8012_reset_energy(supla_hlw8012_t *hlw);
+void ICACHE_FLASH_ATTR supla_hlw8012_get_values(supla_hlw8012_t *hlw,
+                                                uint32 timestamp_us,
+                                                supla_hlw8012_values_t *values);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUPLA_HLW8012_H_ */


### PR DESCRIPTION
### Motivation
- Provide a new board definition (SP111) that uses the previously added HLW8012 driver to obtain power/voltage/current/energy measurements without duplicating logic in board code. 
- Expose user-configurable calibration for HLW voltage and energy in configuration mode so measured values can be adjusted per-hardware tolerances. 
- Integrate HLW pulse handling with existing electricity-meter reporting (Supla extended electricity-meter format) so measurements are sent consistently to the server/MQTT.

### Description
- Added new board files `src/include/board/sp111.h` and `src/include/board/sp111.c` implementing the SP111 board: one relay channel, one electricity-meter channel, GPIO interrupt handling for HLW CF/CF1 pulses, periodic CF1 SEL swapping (voltage/current) and mapping HLW readings into `TElectricityMeter_ExtendedValue_V2` values. 
- Added HLW8012 driver files `src/user/supla_hlw8012.h` and `src/user/supla_hlw8012.c` implementing initialization, CF/CF1 pulse handling, CF1 mode switching, energy reset and value retrieval with stale-time handling and basic PF calculation. 
- Registered the new board in the board dispatcher (`src/include/board/supla_esp_board.h` / `.c`) so it can be selected via `BOARD=sp111`. 
- Extended configuration (`SuplaEspCfg`) in `src/user/supla_esp_cfg.h` with persisted calibration fields `HlwVoltageCalibration` and `HlwEnergyCalibration` and adjusted the `zero` padding accordingly. 
- Extended the cfgmode parser (`src/user/supla_esp_cfgmode.c`) to accept new POST parameters `hvc` (voltage calibration) and `hec` (energy calibration), clamp them to `500..2000` (permille scale), and persist into the new config fields; added a simple board-specific cfg HTML for SP111 exposing `hvc`/`hec`. 

### Testing
- Ran `git diff --check` to ensure there are no whitespace/issues reported by the diff check and it returned no problems (success). 
- Verified presence and integration points with repository-wide searches for new symbols (`rg` checks for `HlwVoltageCalibration`, `HlwEnergyCalibration`, `VAR_HVC`, `VAR_HEC`, and `sp111` references) to confirm parser/board registration changes were applied (success). 
- Full firmware compilation/test on target could not be executed in this environment due to missing ESP8266 SDK/toolchain headers and binaries (toolchain not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b10414e483229523cde5f03e7696)